### PR TITLE
Updated yaml files to use var_templates.pipeline instead of path

### DIFF
--- a/looper_pipelines.md
+++ b/looper_pipelines.md
@@ -6,7 +6,7 @@ Pipelines on this list should be runnable on projects defined using the [standar
 * https://github.com/databio/rnapipe - A set of pipelines specifically for processing RNA.
 * https://github.com/databio/dnameth_pipelines - Pipelines for Whole Genome and Reduced Representation Bisulfite Sequencing (WGBS and RRBS).
 * https://github.com/databio/HiChIP-pipeline - A looper pipeline for processing HiChIP data (wrapper of HiC-pro).
-* http://code.databio.org/PEPATAC - An ATAC-seq pipeline
+* https://pepatac.databio.org/ - An ATAC-seq pipeline
 
 ### Contributing
 

--- a/looper_pipelines.md
+++ b/looper_pipelines.md
@@ -1,6 +1,6 @@
 # Publicly available looper-compatible pipelines
 
-Pipelines on this list should be runnable on projects defined using the [standard PEP project format](https://pepkit.github.io/docs/home/).
+Pipelines on this list should be runnable on projects defined using the [standard PEP project format](http://pep.databio.org/en/latest/).
 
 * https://github.com/epigen/open_pipelines - A collection of pipelines to process diverse sequencing data types, including ATAC-seq, RNA-seq, and others.
 * https://github.com/databio/rnapipe - A set of pipelines specifically for processing RNA.

--- a/pipeline/pipeline_interface.yaml
+++ b/pipeline/pipeline_interface.yaml
@@ -1,5 +1,6 @@
 pipeline_name: count_lines
 pipeline_type: sample
-path: count_lines.sh  # relative to this pipeline_interface.yaml file
+var_templates:
+  pipeline: '{looper.piface_dir}/count_lines.sh'
 command_template: >
-  {pipeline.path} {sample.file}
+  {pipeline.var_templates.pipeline} {sample.file}


### PR DESCRIPTION
Updated yaml files to use var_templates.pipeline instead of path.

1. Using the path variable to point to a pipeline is being deprecated in Looper, so I updated the the sample yaml files to utilize var_templates.
2. Also updated a couple of URLs to point to the new websites.