### PR TITLE
add type: object to pipestat output schema

### DIFF
--- a/pipestat_example/pipeline/pipestat_output_schema.yaml
+++ b/pipestat_example/pipeline/pipestat_output_schema.yaml
@@ -15,6 +15,7 @@ properties:
     type: object
     properties:
       regions_plot:
+        type: object
         description: "This a path to the output image"
         image:
           type: object


### PR DESCRIPTION
bug fix, regions_plot in pipestat_output_schema requires `type`