### PR TITLE
use proper schema format for non-nested schemas

### DIFF
--- a/pipestat_example/pipeline/pipestat_output_schema.yaml
+++ b/pipestat_example/pipeline/pipestat_output_schema.yaml
@@ -15,19 +15,17 @@ properties:
     type: object
     properties:
       regions_plot:
-        type: object
         description: "This a path to the output image"
-        image:
-          type: object
-          object_type: image
-          properties:
-            path:
-              type: string
-            thumbnail_path:
-              type: string
-            title:
-              type: string
-          required:
-            - path
-            - thumbnail_path
-            - title
+        type: object
+        object_type: image
+        properties:
+          path:
+            type: string
+          thumbnail_path:
+            type: string
+          title:
+            type: string
+        required:
+          - path
+          - thumbnail_path
+          - title


### PR DESCRIPTION
proper structure required when using non-nested schema:

```
  project:
    type: object
    properties:
      regions_plot:
        description: "This a path to the output image"
        type: object
        object_type: image
        properties:
          path:
            type: string
          thumbnail_path:
            type: string
          title:
            type: string
        required:
          - path
          - thumbnail_path
          - title
```

regions plot must be of type: object but also have `object_type: image` which is specific to pipestat. Otherwise, objects will not populate the report properly when using `looper report` or `pipestat summarize`